### PR TITLE
[10.x] update @return type in docblock for Process pipe method

### DIFF
--- a/Factory.php
+++ b/Factory.php
@@ -275,7 +275,7 @@ class Factory
      * Start defining a series of piped processes.
      *
      * @param  callable|array  $callback
-     * @return \Illuminate\Process\Pipe
+     * @return ProcessResultContract
      */
     public function pipe(callable|array $callback, ?callable $output = null)
     {


### PR DESCRIPTION
since the pipe is run immediately https://github.com/illuminate/process/commit/d13712e502339d1a42111e51ab0837c4b3655c2d the pipe method doesn't return the `Pipe` anymore, it returns the `ProcessResult`